### PR TITLE
(feat) moving to neoformat for formatting as default option

### DIFF
--- a/ftplugin/python.lua
+++ b/ftplugin/python.lua
@@ -76,7 +76,7 @@ if O.lang.python.autoformat then
   }
 end
 
-if O.plugin.dap_install.active then
+if O.plugin.debug.active and O.plugin.dap_install.active then
   local dap_install = require("dap-install")
   dap_install.config("python_dbg", {})
 end

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -4,6 +4,7 @@ CACHE_PATH = vim.fn.stdpath "cache"
 TERMINAL = vim.fn.expand "$TERMINAL"
 
 O = {
+
   auto_close_tree = 0,
   auto_complete = true,
   colorscheme = "lunar",
@@ -74,6 +75,10 @@ O = {
     telescope_project = { active = false },
     dap_install = { active = false },
     tabnine = { active = false },
+  },
+
+  user_autocommands = {
+    { "FileType", "qf", "set nobuflisted" },
   },
 
   lang = {
@@ -247,56 +252,4 @@ O = {
   },
 }
 
--- TODO find a new home for these autocommands
-require("lv-utils").define_augroups {
-  _general_settings = {
-    {
-      "TextYankPost",
-      "*",
-      "lua require('vim.highlight').on_yank({higroup = 'Search', timeout = 200})",
-    },
-    {
-      "BufWinEnter",
-      "*",
-      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
-    },
-    {
-      "BufRead",
-      "*",
-      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
-    },
-    {
-      "BufNewFile",
-      "*",
-      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
-    },
-    { "VimLeavePre", "*", "set title set titleold=" },
-    { "FileType", "qf", "set nobuflisted" },
-  },
-  -- _solidity = {
-  --     {'BufWinEnter', '.sol', 'setlocal filetype=solidity'}, {'BufRead', '*.sol', 'setlocal filetype=solidity'},
-  --     {'BufNewFile', '*.sol', 'setlocal filetype=solidity'}
-  -- },
-  -- _gemini = {
-  --     {'BufWinEnter', '.gmi', 'setlocal filetype=markdown'}, {'BufRead', '*.gmi', 'setlocal filetype=markdown'},
-  --     {'BufNewFile', '*.gmi', 'setlocal filetype=markdown'}
-  -- },
-  _markdown = {
-    { "FileType", "markdown", "setlocal wrap" },
-    { "FileType", "markdown", "setlocal spell" },
-  },
-  _buffer_bindings = {
-    { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },
-  },
-  _auto_resize = {
-    -- will cause split windows to be resized evenly if main window is resized
-    {'VimResized ', '*', 'wincmd ='},
-  },
-  _mode_switching = {
-    -- will switch between absolute and relative line numbers depending on mode
-    {'InsertEnter', '*', 'if &relativenumber | let g:ms_relativenumberoff = 1 | setlocal number norelativenumber | endif'},
-    {'InsertLeave', '*', 'if exists("g:ms_relativenumberoff") | setlocal relativenumber | endif'},
-    {'InsertEnter', '*', 'if &cursorline | let g:ms_cursorlineoff = 1 | setlocal nocursorline | endif'},
-    {'InsertLeave', '*', 'if exists("g:ms_cursorlineoff") | setlocal cursorline | endif'},
-  },
-}
+

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -292,4 +292,11 @@ require("lv-utils").define_augroups {
     -- will cause split windows to be resized evenly if main window is resized
     {'VimResized ', '*', 'wincmd ='},
   },
+  _mode_switching = {
+    -- will switch between absolute and relative line numbers depending on mode
+    {'InsertEnter', '*', 'if &relativenumber | let g:ms_relativenumberoff = 1 | setlocal number norelativenumber | endif'},
+    {'InsertLeave', '*', 'if exists("g:ms_relativenumberoff") | setlocal relativenumber | endif'},
+    {'InsertEnter', '*', 'if &cursorline | let g:ms_cursorlineoff = 1 | setlocal nocursorline | endif'},
+    {'InsertLeave', '*', 'if exists("g:ms_cursorlineoff") | setlocal cursorline | endif'},
+  },
 }

--- a/lua/lv-compe/init.lua
+++ b/lua/lv-compe/init.lua
@@ -90,7 +90,7 @@ M.config = function()
   vim.api.nvim_set_keymap("s", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
 
   vim.api.nvim_set_keymap("i", "<C-Space>", "compe#complete()", { noremap = true, silent = true, expr = true })
-  vim.api.nvim_set_keymap("i", "<CR>", "compe#confirm('<CR>')", { noremap = true, silent = true, expr = true })
+  -- vim.api.nvim_set_keymap("i", "<CR>", "compe#confirm('<CR>')", { noremap = true, silent = true, expr = true })
   vim.api.nvim_set_keymap("i", "<C-e>", "compe#close('<C-e>')", { noremap = true, silent = true, expr = true })
   vim.api.nvim_set_keymap("i", "<C-f>", "compe#scroll({ 'delta': +4 })", { noremap = true, silent = true, expr = true })
   vim.api.nvim_set_keymap("i", "<C-d>", "compe#scroll({ 'delta': -4 })", { noremap = true, silent = true, expr = true })

--- a/lua/lv-galaxyline/init.lua
+++ b/lua/lv-galaxyline/init.lua
@@ -104,7 +104,7 @@ table.insert(gls.left, {
       vim.api.nvim_command("hi GalaxyViMode guifg=" .. mode_color[vim.fn.mode()])
       return "▊"
     end,
-    -- highlight = 'TabLineSel'
+    highlight = 'StatusLineNC'
     -- highlight = {colors.red, colors.bg}
   },
 })

--- a/lua/lv-utils/init.lua
+++ b/lua/lv-utils/init.lua
@@ -22,4 +22,60 @@ function lv_utils.define_augroups(definitions) -- {{{1
   end
 end
 
+lv_utils.define_augroups {
+
+    _user_autocommands = O.user_autocommands,
+  _general_settings = {
+    {
+      "TextYankPost",
+      "*",
+      "lua require('vim.highlight').on_yank({higroup = 'Search', timeout = 200})",
+    },
+    {
+      "BufWinEnter",
+      "*",
+      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
+    },
+    {
+      "BufRead",
+      "*",
+      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
+    },
+    {
+      "BufNewFile",
+      "*",
+      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
+    },
+    { "VimLeavePre", "*", "set title set titleold=" },
+  },
+  -- _solidity = {
+  --     {'BufWinEnter', '.sol', 'setlocal filetype=solidity'}, {'BufRead', '*.sol', 'setlocal filetype=solidity'},
+  --     {'BufNewFile', '*.sol', 'setlocal filetype=solidity'}
+  -- },
+  -- _gemini = {
+  --     {'BufWinEnter', '.gmi', 'setlocal filetype=markdown'}, {'BufRead', '*.gmi', 'setlocal filetype=markdown'},
+  --     {'BufNewFile', '*.gmi', 'setlocal filetype=markdown'}
+  -- },
+  _markdown = {
+    { "FileType", "markdown", "setlocal wrap" },
+    { "FileType", "markdown", "setlocal spell" },
+  },
+  _buffer_bindings = {
+    { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },
+  },
+  _auto_resize = {
+    -- will cause split windows to be resized evenly if main window is resized
+    {'VimResized ', '*', 'wincmd ='},
+  },
+  -- _mode_switching = {
+  --   -- will switch between absolute and relative line numbers depending on mode
+  --   {'InsertEnter', '*', 'if &relativenumber | let g:ms_relativenumberoff = 1 | setlocal number norelativenumber | endif'},
+  --   {'InsertLeave', '*', 'if exists("g:ms_relativenumberoff") | setlocal relativenumber | endif'},
+  --   {'InsertEnter', '*', 'if &cursorline | let g:ms_cursorlineoff = 1 | setlocal nocursorline | endif'},
+  --   {'InsertLeave', '*', 'if exists("g:ms_cursorlineoff") | setlocal cursorline | endif'},
+  -- },
+}
+
 return lv_utils
+
+-- TODO find a new home for these autocommands

--- a/lua/lv-which-key/init.lua
+++ b/lua/lv-which-key/init.lua
@@ -121,7 +121,14 @@ local mappings = {
       "sort BufferLines automatically by language",
     },
   },
-
+    p = {
+        name = "Packer",
+        c = {"<cmd>PackerCompile<cr>", "Compile"},
+        i = {"<cmd>PackerInstall<cr>", "Install"},
+        r = {":luafile %<cr>", "Reload"},
+        s = {"<cmd>PackerSync<cr>", "Sync"},
+        u = {"<cmd>PackerUpdate<cr>", "Update"}
+    },
   -- diagnostics vanilla nvim
   -- -- diagnostic
   -- function lv_utils.get_all()

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -254,7 +254,7 @@ return require("packer").startup(function(use)
     "mfussenegger/nvim-dap",
     config = function()
         require('dap')
-        vim.fn.sign_define('DapBreakpoint', {text='🛑', texthl='', linehl='', numhl=''})
+        vim.fn.sign_define('DapBreakpoint', {text='', texthl='LspDiagnosticsSignError', linehl='', numhl=''})
         require('dap').defaults.fallback.terminal_win_cmd = '50vsplit new'
     end,
     disable = not O.plugin.debug.active,

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -97,6 +97,8 @@ O.lang.php.filetypes = { "php", "phtml" }
 
 -- TODO Autocommands
 -- https://neovim.io/doc/user/autocmd.html
+-- local test = { "BufWinEnter", "*", "echo \"hi again\""}
+-- table.insert(O.user_autocommands, test)
 
 -- TODO Additional Plugins
 


### PR DESCRIPTION
* Get rid of all unnecessary complexity for setting up efm for formatting

* No need for efm server since it's no going to be used for formatting
  (some languages need it for lint, e.g python, if those cases the efm
  server was left and not completely removed)

*  Add `forma_on_save` option and remove all unnecessary format options for specific languages

### Benefits

1. Users can toggle format_on_save for all languages, and not have an option for every single language as it was before.
2. We don't need to worry about setting up formatters with efm anymore (which can a pain to do)
3. Simple the config, and get rid of a ton of unnecessary settings for specific languages. We don't have to parse x formatter that an users wants to efm or whatever. Just having the formatter you want and in your path will work out of the box.

Hey @ChristianChiarulli this is done, and tested in my machine, all working as expected. Take a look a let me know if you want any change (also test this to be 100% sure before merging)